### PR TITLE
use -global with condor_q

### DIFF
--- a/server.py
+++ b/server.py
@@ -211,7 +211,7 @@ def get_condor_version():
 def condor_q(cfg):
     """Get the status of the HTCondor queue"""
     logger.info('condor_q')
-    cmd = ['condor_q', '-autoformat:,', 'RequestCPUs', 'RequestMemory',
+    cmd = ['condor_q', '-global', '-autoformat:,', 'RequestCPUs', 'RequestMemory',
            'RequestDisk', 'RequestGPUs', '-format', '"%s"', 'Requirements',
            '-constraint', '"JobStatus =?= 1"']
     if cfg['options'].constraint:


### PR DESCRIPTION
Update server.py to run condor_q with -global, so that it doesn't have to run on the same machine as condor_schedd and works with pools with multiple submitters.