### PR TITLE
enable condor runtime config

### DIFF
--- a/glidein_start.sh
+++ b/glidein_start.sh
@@ -67,6 +67,9 @@ export _condor_ICECUBE_CVMFS_Exists="${CVMFS}"
 
 export _condor_CONDOR_HOST="$CLUSTER"
 export _condor_COLLECTOR_HOST="${CLUSTER}:9618?sock=collector"
+export _condor_ALLOW_CONFIG="$CLUSTER"
+export _condor_ENABLE_RUNTIME_CONFIG="True"
+export _condor_SETTABLE_ATTRS_CONFIG="*"
 export _condor_GLIDEIN_Site="\"${SITE}\""
 export _condor_GLIDEIN_HOST="$CLUSTER"
 export _condor_GLIDEIN_Max_Walltime=${WALLTIME};


### PR DESCRIPTION
Allow running glideins to be configured from the central manager using condor_config_val