### PR TITLE
add the redhat-lsb-core freetype packages to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 RUN chmod +x /sbin/tini
 
-RUN yum -y install git wget curl libtool-ltdl libgomp
+RUN yum -y install git wget curl libtool-ltdl libgomp redhat-lsb-core freetype
 
 RUN useradd --create-home --shell /bin/bash condor
 


### PR DESCRIPTION
 (necessary for icecube cvmfs auto-detection and python)

* cvmfs setup.sh needs lsb_release to work properly in containers.
* it seems that a lot of icetray/cvmfs expects freetype to be installed on the local system

-> this makes jobs actually run