### PR TITLE
Reduce the RAM requested per GPU. Comet complains if larger.

### DIFF
--- a/configs/comet.config
+++ b/configs/comet.config
@@ -30,7 +30,7 @@ idle_cmd = squeue -u $USER -t PENDING -p gpu -h | wc -l
 [gpu-shared]
 gpu_only = True
 whole_node = True
-whole_node_memory = 30000
+whole_node_memory = 25000
 whole_node_cpus = 6
 whole_node_disk = 400000
 whole_node_gpus = 1


### PR DESCRIPTION
Apparently 30000 is too close to the max memory per GPU in the gpu-shared partition. Lowering it to 25000 appears to be ok and it is probably good for our needs.