### PR TITLE
Adding support for startd checks

### DIFF
--- a/dev_build/client/root/etc/sv/pyglidein_client/htcondor_config
+++ b/dev_build/client/root/etc/sv/pyglidein_client/htcondor_config
@@ -96,3 +96,6 @@ http_proxy = http://squid.icecube.wisc.edu:3128
 send_startd_logs = True
 url = s3.amazonaws.com
 bucket = pyglidein-logging-wipac-dev
+
+[StardChecks]
+enable_startd_checks = True

--- a/dev_build/client/root/setup.sh
+++ b/dev_build/client/root/setup.sh
@@ -7,6 +7,7 @@ yum clean all
 yum -y install \
 cron \
 epel-release \
+freetype \
 glibc-static \
 libgomp \
 libstdc++-static \

--- a/dev_build/client_pbs_torque/root/setup.sh
+++ b/dev_build/client_pbs_torque/root/setup.sh
@@ -5,6 +5,7 @@ yum clean all
 yum -y install \
 boost-devel \
 epel-release \
+freetype \
 glibc-static \
 iproute \
 libgomp \
@@ -42,6 +43,7 @@ cd /
 useradd pyglidein
 chmod 777 /home/pyglidein
 yum -y install python-pip
+pip install --upgrade setuptools
 pip install ./pyglidein*
 
 # Downloading pyglidein tarball
@@ -86,7 +88,6 @@ ln -s /etc/sv/pbs_mom /etc/service/pbs_mom
 ln -s /etc/sv/pbs_server /etc/service/pbs_server
 ln -s /etc/sv/pbs_sched /etc/service/pbs_sched
 ln -s /etc/sv/pyglidein_client /etc/service/pyglidein_client
-#ln -s /etc/sv/autofs /etc/service/autofs
 
 # Creating data directory
 mkdir /data/
@@ -96,7 +97,7 @@ mkdir /data/log/pbs_mom
 mkdir /data/log/pbs_sched
 mkdir /data/log/pbs_server
 mkdir /data/log/pyglidein_client
-#mkdir /data/log/autofs
+mkdir /data/log/autofs
 
 # Removing packages
 #yum -y groupremove 'Development Tools'

--- a/dev_build/docker-compose.yml
+++ b/dev_build/docker-compose.yml
@@ -15,8 +15,14 @@ services:
     hostname: pyglidein-client
     privileged: true
     volumes:
+      - "/etc/OpenCL:/etc/OpenCL"
       - "../:/pyglidein"
       - "~/.pyglidein_secrets:/home/pyglidein/.pyglidein_secrets"
+      - nvidia_driver_384.90:/usr/local/nvidia:ro
+    devices:
+      - /dev/nvidia0:/dev/nvidia0
+      - /dev/nvidiactl:/dev/nvidiactl
+      - /dev/nvidia-uvm:/dev/nvidia-uvm
   minio:
     image: minio/minio
     networks:
@@ -34,3 +40,6 @@ networks:
       config:
         -
           subnet: 172.22.0.0/24
+volumes:
+  nvidia_driver_384.90:
+    external: true

--- a/dev_build/docker-compose_pbs_torque.yml
+++ b/dev_build/docker-compose_pbs_torque.yml
@@ -14,8 +14,14 @@ services:
       app_net:
     hostname: pyglidein-client-pbs-torque
     volumes:
+      - "/etc/OpenCL:/etc/OpenCL"
       - "../:/pyglidein"
       - "~/.pyglidein_secrets:/home/pyglidein/.pyglidein_secrets"
+      - nvidia_driver_384.90:/usr/local/nvidia:ro
+    devices:
+      - /dev/nvidia0:/dev/nvidia0
+      - /dev/nvidiactl:/dev/nvidiactl
+      - /dev/nvidia-uvm:/dev/nvidia-uvm
     privileged: true
   minio:
     image: minio/minio
@@ -34,3 +40,6 @@ networks:
       config:
         -
           subnet: 172.22.0.0/24
+volumes:
+  nvidia_driver_384.90:
+    external: true

--- a/dev_build/server/root/setup.sh
+++ b/dev_build/server/root/setup.sh
@@ -3,6 +3,7 @@
 # Installing base packages
 yum -y install \
 epel-release \
+freetype \
 glibc-static \
 libgomp \
 libstdc++-static \
@@ -29,6 +30,7 @@ chmod 755 /home/condor/condor-8.7.2/condor.sh
 useradd pyglidein
 chmod 777 /home/pyglidein
 yum -y install python-pip
+pip install --upgrade setuptools
 pip install ./pyglidein*
 
 # Installing Runit

--- a/pyglidein/glidein_start.sh
+++ b/pyglidein/glidein_start.sh
@@ -130,6 +130,25 @@ export _campusfactory_CAMPUSFACTORY_LOCATION=$PWD
 export _condor_USER_JOB_WRAPPER=$PWD/user_job_wrapper.sh
 export _condor_PRESIGNED_GET_URL="\"$PRESIGNED_GET_URL\""
 
+# STARTD CRON
+if [ -z $DISABLE_STARTD_CHECKS ]; then
+  export _condor_STARTD_CRON_JOBLIST='clsimgpu cvmfs gridftp'
+  export _condor_STARTD_CRON_CLSIMGPU_MODE='OneShot'
+  export _condor_STARTD_CRON_CLSIMGPU_RECONFIG_RERUN='True'
+  export _condor_STARTD_CRON_CLSIMGPU_EXECUTABLE='../../post_cvmfs.sh'
+  export _condor_STARTD_CRON_CLSIMGPU_ARGS='../../clsim_gpu_test.py -n 1'
+  export _condor_STARTD_CRON_CVMFS_MODE='OneShot'
+  export _condor_STARTD_CRON_CVMFS_RECONFIG_RERUN='True'
+  export _condor_STARTD_CRON_CVMFS_EXECUTABLE='../../pre_cvmfs.sh'
+  export _condor_STARTD_CRON_CVMFS_ARGS='../../cvmfs_test.py /cvmfs/icecube.opensciencegrid.org/py2-v1/RHEL_6_x86_64/bin/globus-url-copy 36648bd8463ecfc7464042628905d490'
+  export _condor_STARTD_CRON_GRIDFTP_MODE='OneShot'
+  export _condor_STARTD_CRON_GRIDFTP_RECONFIG_RERUN='True'
+  export _condor_STARTD_CRON_GRIDFTP_EXECUTABLE='../../post_cvmfs.sh'
+  export _condor_STARTD_CRON_GRIDFTP_ARGS='../../gridftp_test.py gridftp.icecube.wisc.edu 2811'
+  export _condor_ALL_DEBUG='D_ALL'
+fi
+
+
 # detect CVMFS and get the OS type
 OS_ARCH="RHEL_6_x86_64"
 . $GLIDEIN_DIR/os_arch.sh

--- a/pyglidein/glidein_start.sh
+++ b/pyglidein/glidein_start.sh
@@ -145,7 +145,6 @@ if [ -z $DISABLE_STARTD_CHECKS ]; then
   export _condor_STARTD_CRON_GRIDFTP_RECONFIG_RERUN='True'
   export _condor_STARTD_CRON_GRIDFTP_EXECUTABLE='../../post_cvmfs.sh'
   export _condor_STARTD_CRON_GRIDFTP_ARGS='../../gridftp_test.py gridftp.icecube.wisc.edu 2811'
-  export _condor_ALL_DEBUG='D_ALL'
 fi
 
 

--- a/pyglidein/startd_cron_scripts/clsim_gpu_test.py
+++ b/pyglidein/startd_cron_scripts/clsim_gpu_test.py
@@ -15,25 +15,26 @@ def main():
 
     usage = "usage: %prog [options]"
     parser = OptionParser(usage)
-    parser.add_option('-n', type='int', default=1,
+    parser.add_option('-n', type='str', default=1,
                       help="Number of simulations to run")
     (options, args) = parser.parse_args()
 
     try:
         # This line is needed to access the nvidia gpus via OpenCL inside a container.
         # TODO: Is this needed in a grid environment?
-        os.environ['LD_LIBRARY_PATH'] = ('/usr/local/nvidia/lib64:'
-                                         '{}'.format(os.environ['LD_LIBRARY_PATH']))
+        os.environ['LD_LIBRARY_PATH'] = ('/usr/local/nvidia/lib64:' +
+                                         os.environ['LD_LIBRARY_PATH'])
 
-        cmd = '{} {}'.format(os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
-                                          os.environ['OS_ARCH'],
-                                          'metaprojects/simulation/V05-00-07/env-shell.sh'),
-                             os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
-                                          os.environ['OS_ARCH'],
-                                          'metaprojects/simulation/V05-00-07/clsim/resources',
-                                          'scripts/benchmark.py'))
-        cmd += ' -n {}'.format(options.n)
-        check_output(cmd, shell=True, env=os.environ, stderr=STDOUT)
+        cmd = []
+        cmd.append(os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
+                                os.environ['OS_ARCH'],
+                                'metaprojects/simulation/V05-00-07/env-shell.sh'))
+        cmd.append(os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
+                                os.environ['OS_ARCH'],
+                                'metaprojects/simulation/V05-00-07/clsim/resources',
+                                'scripts/benchmark.py'))
+        cmd.extend(['-n', options.n])
+        check_output(cmd, shell=False, env=os.environ, stderr=STDOUT)
 
         tree = ET.parse(OUTPUT_FILE)
         root = tree.getroot()

--- a/pyglidein/startd_cron_scripts/clsim_gpu_test.py
+++ b/pyglidein/startd_cron_scripts/clsim_gpu_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import os
+from optparse import OptionParser
+from subprocess import check_output, STDOUT
+import xml.etree.ElementTree as ET
+
+OUTPUT_FILE = 'benchmark.xml'
+
+CLASSAD_MAP = {'I3CLSimModule_makeCLSimHits_makePhotons_clsim_AverageDeviceTimePerPhoton':
+               'PYGLIDEIN_METRIC_TIME_PER_PHOTON'}
+
+
+def main():
+
+    usage = "usage: %prog [options]"
+    parser = OptionParser(usage)
+    parser.add_option('-n', type='int', default=1,
+                      help="Number of simulations to run")
+    (options, args) = parser.parse_args()
+
+    try:
+        # This line is needed to access the nvidia gpus via OpenCL inside a container.
+        # TODO: Is this needed in a grid environment?
+        os.environ['LD_LIBRARY_PATH'] = ('/usr/local/nvidia/lib64:'
+                                         '{}'.format(os.environ['LD_LIBRARY_PATH']))
+
+        cmd = '{} {}'.format(os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
+                                          os.environ['OS_ARCH'],
+                                          'metaprojects/simulation/V05-00-07/env-shell.sh'),
+                             os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',
+                                          os.environ['OS_ARCH'],
+                                          'metaprojects/simulation/V05-00-07/clsim/resources',
+                                          'scripts/benchmark.py'))
+        cmd += ' -n {}'.format(options.n)
+        check_output(cmd, shell=True, env=os.environ, stderr=STDOUT)
+
+        tree = ET.parse(OUTPUT_FILE)
+        root = tree.getroot()
+        for child in root[0][1]:
+            if child.tag == 'item' and child[0].text in CLASSAD_MAP:
+                    print '{}={}'.format(CLASSAD_MAP[child[0].text], child[1].text)
+
+        print 'PYGLIDEIN_RESOURCE_GPU=True'
+        print '- update:true'
+    except:
+        print 'PYGLIDEIN_RESOURCE_GPU=False'
+        print '- update:true'
+
+
+if __name__ == '__main__':
+    main()

--- a/pyglidein/startd_cron_scripts/clsim_gpu_test.py
+++ b/pyglidein/startd_cron_scripts/clsim_gpu_test.py
@@ -23,7 +23,7 @@ def main():
         # This line is needed to access the nvidia gpus via OpenCL inside a container.
         # TODO: Is this needed in a grid environment?
         os.environ['LD_LIBRARY_PATH'] = ('/usr/local/nvidia/lib64:' +
-                                         os.environ['LD_LIBRARY_PATH'])
+                                         os.environ.get('LD_LIBRARY_PATH', '')
 
         cmd = []
         cmd.append(os.path.join('/cvmfs/icecube.opensciencegrid.org/py2-v2',

--- a/pyglidein/startd_cron_scripts/cvmfs_test.py
+++ b/pyglidein/startd_cron_scripts/cvmfs_test.py
@@ -19,8 +19,8 @@ def main():
 
     try:
         if os.path.isfile(cvmfs_test_file):
-            cmd = 'md5sum {}'.format(cvmfs_test_file)
-            output = check_output(cmd, shell=True, env=os.environ, stderr=STDOUT)
+            cmd = ['md5sum', cvmfs_test_file]
+            output = check_output(cmd, shell=False, env=os.environ, stderr=STDOUT)
             if cvmfs_md5sum not in output:
                 raise Exception()
         else:

--- a/pyglidein/startd_cron_scripts/cvmfs_test.py
+++ b/pyglidein/startd_cron_scripts/cvmfs_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+from optparse import OptionParser
+from subprocess import check_output, STDOUT
+
+
+def main():
+
+    usage = "usage: %prog [options] FILE MD5SUM"
+    parser = OptionParser(usage)
+
+    (options, args) = parser.parse_args()
+
+    if len(args) != 2:
+        raise Exception('Number Of Args != 2')
+    cvmfs_test_file = args[0]
+    cvmfs_md5sum = args[1]
+
+    try:
+        if os.path.isfile(cvmfs_test_file):
+            cmd = 'md5sum {}'.format(cvmfs_test_file)
+            output = check_output(cmd, shell=True, env=os.environ, stderr=STDOUT)
+            if cvmfs_md5sum not in output:
+                raise Exception()
+        else:
+            raise Exception()
+        # If we got this far CVMFS must work
+        print 'PYGLIDEIN_RESOURCE_CVMFS=True'
+        print '- update:true'
+    except:
+        print 'PYGLIDEIN_RESOURCE_CVMFS=False'
+        print '- update:true'
+
+
+if __name__ == '__main__':
+    main()

--- a/pyglidein/startd_cron_scripts/gridftp_test.py
+++ b/pyglidein/startd_cron_scripts/gridftp_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from optparse import OptionParser
+from telnetlib import Telnet
+
+
+def main():
+
+    usage = "usage: %prog [options] GRIDFTP_SERVER_FQDN GRIDFTP_SERVER_PORT"
+    parser = OptionParser(usage)
+    parser.add_option('--timeout', type='int', default=5,
+                      help="Telnet timeout value in seconds")
+    (options, args) = parser.parse_args()
+
+    if len(args) != 2:
+        raise Exception('Number Of Args != 2')
+    gridftp_server_name = args[0]
+    gridftp_server_port = args[1]
+
+    try:
+        gridftp_connection = Telnet(gridftp_server_name, gridftp_server_port, options.timeout)
+        output = gridftp_connection.read_until('ready.', options.timeout)
+        for txt in ['220', 'GridFTP Server', 'ready']:
+            if txt not in output:
+                raise Exception()
+        gridftp_connection.close()
+
+        print 'PYGLIDEIN_RESOURCE_GRIDFTP=True'
+        print '- update:true'
+    except:
+        print 'PYGLIDEIN_RESOURCE_GRIDFTP=False'
+        print '- update:true'
+
+
+if __name__ == '__main__':
+    main()

--- a/pyglidein/startd_cron_scripts/post_cvmfs.sh
+++ b/pyglidein/startd_cron_scripts/post_cvmfs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+eval `/cvmfs/icecube.opensciencegrid.org/py2-v2/setup.sh`
+
+exec env $@

--- a/pyglidein/startd_cron_scripts/pre_cvmfs.sh
+++ b/pyglidein/startd_cron_scripts/pre_cvmfs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec env $@

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ setup(
     packages=find_packages(),
     install_requires=['minio;python_version>"2.6"', 'tornado'],
     package_data={
-        'pyglidein': ['glidein_start.sh', 'log_shipper.sh', 'os_arch.sh']
+        'pyglidein': ['glidein_start.sh', 'log_shipper.sh', 'os_arch.sh',
+                      'startd_cron_scripts/clsim_gpu_test.py',
+                      'startd_cron_scripts/cvmfs_test.py',
+                      'startd_cron_scripts/gridftp_test.py',
+                      'startd_cron_scripts/post_cvmfs.sh',
+                      'startd_cron_scripts/pre_cvmfs.sh']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Pyglidein now sets scripts for checking GPUs, CVMFS, and GridFTP services on each node.  The scripts are hooked into condor startd cron service and produce classads based on the success or failure of the check script. The GPU scrip also outputs a metrics classad for measuring the performance of GPUs. Resolve #104 