### PR TITLE
Allow setting mem only for pbs submit.

### DIFF
--- a/docs/configuration_index.md
+++ b/docs/configuration_index.md
@@ -2,6 +2,9 @@
 
 List of available configuration options.
 
+## [Cluster]
+mem_only: True/False. Set only mem requirement for PBS (default: False).
+
 ## [StartdChecks]
 
 * enable_startd_checks: True/False.  Enable or disable Startd monitoring checks. 

--- a/pyglidein/submit.py
+++ b/pyglidein/submit.py
@@ -130,6 +130,8 @@ class SubmitPBS(Submit):
             self.write_option(f, "-l pmem=%dmb,vmem=%dmb" % (mem,mem*num_cpus))
         elif cluster_config.get("vmem_only", False):
             self.write_option(f, "-l vmem=%dmb" % mem)
+        elif cluster_config.get("mem_only", False):
+            self.write_option(f, "-l mem=%dmb" % mem)
         else:
             self.write_option(f, "-l pmem=%dmb,mem=%dmb" % (mem,mem*num_cpus))
         self.write_option(f, "-l walltime=%d:00:00" % walltime_hours)


### PR DESCRIPTION
In our cluster, we need to set only the mem option (setting pmem and mem is not correct in our case).