### PR TITLE
Allow not writing gpus requirement for pbs.

### DIFF
--- a/docs/configuration_index.md
+++ b/docs/configuration_index.md
@@ -4,6 +4,7 @@ List of available configuration options.
 
 ## [Cluster]
 mem_only: True/False. Set only mem requirement for PBS (default: False).
+set_gpu_req: True/False. Set gpus requirement for PBS (default: True).
 
 ## [StartdChecks]
 

--- a/pyglidein/submit.py
+++ b/pyglidein/submit.py
@@ -120,7 +120,7 @@ class SubmitPBS(Submit):
         node_property = cluster_config.get("node_property", False)
         if node_property:
             resource_line +=':%s' % (node_property)
-        if num_gpus > 0:
+        if num_gpus > 0 and cluster_config.get("set_gpu_req", True):
             resource_line += ':gpus=%d' % (num_gpus)
         self.write_option(f, resource_line)
 


### PR DESCRIPTION
In our cluster, setting gpus requirement crashes the submission (pbs not built with gpu extension).
This option allows us to not set this requirement while being backward compatible for other configs.
(with give the whole node to 1 pilot job, gpus definition CUDA_VISIBLE_DEVICES is done via a custom script)