### PR TITLE
update Dockerfile to support GPU containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,32 @@
-# A RHEL6 container running a pyglidein
+# A RHEL7+cuda container running a pyglidein
 
-FROM centos:6
+# FROM centos:6
+FROM nvidia/cuda:9.0-runtime-centos7
+
 MAINTAINER Claudio Kopper <kopper@ualberta.ca>
-ENV TINI_VERSION v0.14.0
+ENV TINI_VERSION v0.18.0
 
 WORKDIR /root
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 RUN chmod +x /sbin/tini
 
-RUN yum -y install git wget curl libtool-ltdl libgomp redhat-lsb-core freetype
+# Enable OpenCL
+RUN yum install -y epel-release && \
+    yum install -y ocl-icd ocl-icd-devel clinfo && \
+    rm -rf /var/cache/yum && \
+    mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+
+RUN yum -y install git wget curl libtool-ltdl libgomp redhat-lsb-core freetype libquadmath && \
+    rm -rf /var/cache/yum
 
 RUN useradd --create-home --shell /bin/bash condor
 
 RUN mkdir -p /home/condor/pyglidein
-RUN curl -o /home/condor/pyglidein/glidein.tar.gz http://prod-exe.icecube.wisc.edu/glidein-RHEL_6_x86_64.tar.gz
+RUN curl -o /home/condor/pyglidein/glidein.tar.gz http://prod-exe.icecube.wisc.edu/glidein-RHEL_7_x86_64.tar.gz
 
-COPY . /home/condor/pyglidein
+COPY pyglidein/ /home/condor/pyglidein
 RUN chown -R condor:condor /home/condor/pyglidein
 
 USER condor

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV SITE=dockerized_pyglidein \
     DISK=8000000 \
     WALLTIME=72000
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/home/condor/pyglidein/glidein_start.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/home/condor/pyglidein/glidein_start_in_docker.sh"]

--- a/pyglidein/glidein_start.sh
+++ b/pyglidein/glidein_start.sh
@@ -53,11 +53,17 @@ CVMFS="True"
 GPU_NAMES=""
 if [ $GPUS != 0 ]; then
     if command -v nvidia-smi >/dev/null; then
-        GPU2=$(echo "$GPUS"|sed 's/CUDA//g');
-        GPU_NAMES=$(nvidia-smi --query-gpu=name --format=csv,noheader --id=$GPU2|sed ':a;N;$!ba;s/\n/,/g');
+        if [ "$GPUS" = "all" ]; then
+            GPU_NAMES=$(nvidia-smi --query-gpu=name --format=csv,noheader|sed ':a;N;$!ba;s/\n/,/g');
+        else
+            GPU2=$(echo "$GPUS"|sed 's/CUDA//g');
+            GPU_NAMES=$(nvidia-smi --query-gpu=name --format=csv,noheader --id=$GPU2|sed ':a;N;$!ba;s/\n/,/g');
+        fi
+    else
+        # GPUs might exist but nvidia-smi is not available. re-set $GPUS
+        GPUS=0
     fi
 fi
-
 
 ##
 # Done with config

--- a/pyglidein/glidein_start.sh
+++ b/pyglidein/glidein_start.sh
@@ -66,7 +66,7 @@ fi
 export GOTO_NUM_THREADS=1
 
 # assume you are already in a scratch directory
-mkdir glidein
+mkdir -p glidein
 cd glidein
 
 export _condor_OASIS_CVMFS_Exists="${CVMFS}"

--- a/pyglidein/glidein_start_in_docker.sh
+++ b/pyglidein/glidein_start_in_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+if [ -z $GPUS ]; then
+    export GPUS=0
+fi
+
+if [ $GPUS != 0 ]; then
+    # Override $GPUS with whatever is in $NVIDIA_VISIBLE_DEVICES.
+    # We assume that this script is only used inside of a conatiner built
+    # from nvidia/cuda and decendants, so $NVIDIA_VISIBLE_DEVICES should
+    # always be set to *something*.
+    # (https://github.com/nvidia/nvidia-container-runtime#environment-variables-oci-spec)
+    if [ -z $NVIDIA_VISIBLE_DEVICES ]; then
+        echo "expected NVIDIA_VISIBLE_DEVICES to be set. Unexpectedly, it is not. Will set GPUS=0"
+        export GPUS=0
+    else
+        if [ "$NVIDIA_VISIBLE_DEVICES" = "none" ]; then
+            export GPUS=0
+        else
+            # echo "setting GPUS to NVIDIA_VISIBLE_DEVICES. GPUS=$NVIDIA_VISIBLE_DEVICES"
+            export GPUS=$NVIDIA_VISIBLE_DEVICES
+        fi
+    fi
+fi
+
+echo "Starting dockerized pyglidein with GPUS=$GPUS"
+
+# now run glidein_start.sh
+exec $PWD/glidein_start.sh


### PR DESCRIPTION
A small update to the dockerfile in order to base it off the nvidia/cuda containers. This also includes a change that makes the startup script not fail in case a `glidein` directory already exists (I mount a scratch directory there on my nodes so the mountpoint has to exist before the tarball in unpacked).