### PR TITLE
Modify cedar config to run under iceprod account

### DIFF
--- a/configs/cedar.config
+++ b/configs/cedar.config
@@ -16,18 +16,18 @@ partitions = cpus
 cpu_only = True
 whole_node = True
 whole_node_cpus = 2
-whole_node_memory = 4000
-mem_per_core = 4000
+whole_node_memory = 18000
+mem_per_core = 9000
 whole_node_disk = 20000
 running_cmd = squeue -u $USER |grep $USER|grep " R " | wc -l
 idle_cmd = squeue -u $USER  |grep $USER|grep -v " R " |wc -l
-max_total_jobs = 50
-max_idle_jobs = 20
-limit_per_submit = 5
-submit_command = sbatch --account=rpp-kenclark
+max_total_jobs = 500
+max_idle_jobs = 200
+limit_per_submit = 10
+submit_command = sbatch --nice --account=rpp-kenclark
 
 [SubmitFile]
-executable = ~/projects/def-kenclark-ab/jrajewsk/pyglidein/pyglidein/glidein_start_singularity.sh
+executable = /scratch/iceprod/pyglidein/pyglidein/glidein_start_singularity.sh
 custom_middle = module load singularity/3.2
 local_dir = $SLURM_TMPDIR
 


### PR DESCRIPTION
Move pyglideins on cedar to a more permanent location, and also increase memory to pick up more glidein jobs