### PR TITLE
Sort requests only on columns in prioritize_jobs

### DIFF
--- a/pyglidein/client.py
+++ b/pyglidein/client.py
@@ -72,7 +72,7 @@ def sort_states(state, columns, reverse=True):
             v = row[k]
             if k in col_cache:
                 v *= col_cache[k]
-            ret.append(v)
+                ret.append(v)
         return ret
     return sorted(state, key=compare, reverse=reverse)
 


### PR DESCRIPTION
This prevents attempts to sort on e.g. `os`, which is either str or None.

Fixes #169.