### PR TITLE
Fixes the cleanup of pyglideins

### DIFF
--- a/pyglidein/client.py
+++ b/pyglidein/client.py
@@ -191,7 +191,7 @@ def main():
                     continue
                 info['glideins_launched'][partition] = 0
                 limit = min(config_cluster["limit_per_submit"],
-                            config_cluster["max_total_jobs"] - info['glideins_running'][partition],
+                            config_cluster["max_total_jobs"] - info['glideins_running'][partition] - idle,
                             max(config_cluster.get("max_idle_jobs", 1000) - idle, 0))
                 # Prioitize job submission. By default, prioritize submission of gpu and high memory jobs.
                 state = sort_states(state, config_cluster["prioritize_jobs"])

--- a/pyglidein/glidein_start.sh
+++ b/pyglidein/glidein_start.sh
@@ -291,7 +291,7 @@ fi
 
 wait $PID
 trap - SIGTERM SIGKILL
-wait $PID
+
 if [ -n "$PRESIGNED_PUT_URL" ]
   then
     tar czf logs.tar.gz log.*

--- a/pyglidein/submit.py
+++ b/pyglidein/submit.py
@@ -232,7 +232,7 @@ class SubmitPBS(Submit):
                 if not os.path.isfile(script_path):
                     raise Exception("Stard cron script not found: {}".format(script))
                 self.write_line(f, 'cp %s %s' % (script_path, script))
-        f.write('exec env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK WALLTIME=$WALLTIME '
+        f.write('env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK WALLTIME=$WALLTIME '
                 'DISABLE_STARTD_CHECKS=$DISABLE_STARTD_CHECKS ')
         if 'site' in self.config['Glidein']:
             f.write('SITE=$SITE ')
@@ -612,7 +612,7 @@ class SubmitCondor(Submit):
                 self.write_line(f, 'ResourceName=$(grep -e "^GLIDEIN_ResourceName" $_CONDOR_MACHINE_AD|awk -F "= " "{print \\$2}"|sed "s/\\"//g")')
             if 'cluster' in self.config['Glidein']:
                 self.write_line(f, 'CLUSTER="%s"' % self.config['Glidein']['cluster'])
-            f.write('exec env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK '
+            f.write('env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK '
                     'PRESIGNED_PUT_URL=$PRESIGNED_PUT_URL PRESIGNED_GET_URL=$PRESIGNED_GET_URL ')
             if 'site' in self.config['Glidein']:
                 f.write('SITE=$SITE ')

--- a/pyglidein/submit.py
+++ b/pyglidein/submit.py
@@ -233,7 +233,8 @@ class SubmitPBS(Submit):
                     raise Exception("Stard cron script not found: {}".format(script))
                 self.write_line(f, 'cp %s %s' % (script_path, script))
         f.write('env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK WALLTIME=$WALLTIME '
-                'DISABLE_STARTD_CHECKS=$DISABLE_STARTD_CHECKS ')
+                'DISABLE_STARTD_CHECKS=$DISABLE_STARTD_CHECKS '
+                'TMPDIR=$TMPDIR TEMP=$TEMP TMP=$TMP ')
         if 'site' in self.config['Glidein']:
             f.write('SITE=$SITE ')
         if 'resourcename' in self.config['Glidein']:
@@ -613,7 +614,8 @@ class SubmitCondor(Submit):
             if 'cluster' in self.config['Glidein']:
                 self.write_line(f, 'CLUSTER="%s"' % self.config['Glidein']['cluster'])
             f.write('env -i CPUS=$CPUS GPUS=$GPUS MEMORY=$MEMORY DISK=$DISK '
-                    'PRESIGNED_PUT_URL=$PRESIGNED_PUT_URL PRESIGNED_GET_URL=$PRESIGNED_GET_URL ')
+                    'PRESIGNED_PUT_URL=$PRESIGNED_PUT_URL PRESIGNED_GET_URL=$PRESIGNED_GET_URL '
+                    'TMPDIR=$TMPDIR TEMP=$TEMP TMP=$TMP ')
             if 'site' in self.config['Glidein']:
                 f.write('SITE=$SITE ')
             if 'resourcename' in self.config['Glidein']:


### PR DESCRIPTION
Fix the cleanup of the glideins local_dir: The glideins built-in cleanup was never executed for two reasons: First, there is a second `wait $PID` statement just after an identical one two lines above which will always fail with `wait: pid [...] is not a child of this shell`. Second, the parent job exited right away when `glidein_start.sh` exit since it the glidein beeing called with `exec`. Both issues prevented the local_dir cleanup and any `custom_end` command from beeing executed.

Also, pass TMPDIR, TEMP and TMP to the glideins shell to ensure that e.g. the OpenCL libraries are put into TMPDIR by the cvmf setup script. Without these environment variables defined, `tempfil.gettempdir()` falls back to using `/tmp`.
